### PR TITLE
Use QoS properties for response message creation.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@
   
   <artifactId>MAL_IMPL</artifactId>
   <packaging>jar</packaging>
-  <version>1.0</version>
+  <version>1.1-SNAPSHOT</version>
 
   <name>ESA MAL Java Implementation</name>
   <description>The ESA implementation of the CCSDS MAL in Java</description>

--- a/src/main/java/esa/mo/mal/impl/MessageReceive.java
+++ b/src/main/java/esa/mo/mal/impl/MessageReceive.java
@@ -416,6 +416,7 @@ public class MessageReceive implements MALMessageListener
                 MALPubSubOperation.REGISTER_ACK_STAGE,
                 true,
                 interaction.getOperation(),
+                interaction.getQoSProperties(),
                 (Object[]) null);
       }
       else
@@ -463,7 +464,7 @@ public class MessageReceive implements MALMessageListener
                 transId,
                 msg.getHeader(),
                 lvl,
-                MALPubSubOperation.PUBLISH_REGISTER_ACK_STAGE, true, interaction.getOperation(), (Object[]) null);
+                MALPubSubOperation.PUBLISH_REGISTER_ACK_STAGE, true, interaction.getOperation(), interaction.getQoSProperties(), (Object[]) null);
       }
       else
       {
@@ -648,6 +649,7 @@ public class MessageReceive implements MALMessageListener
                 MALPubSubOperation.DEREGISTER_ACK_STAGE,
                 true,
                 interaction.getOperation(),
+                interaction.getQoSProperties(),
                 (Object[]) null);
       }
       catch (MALException ex)
@@ -695,7 +697,7 @@ public class MessageReceive implements MALMessageListener
               transId,
               msg.getHeader(),
               lvl,
-              MALPubSubOperation.PUBLISH_DEREGISTER_ACK_STAGE, true, interaction.getOperation(), (Object[]) null);
+              MALPubSubOperation.PUBLISH_DEREGISTER_ACK_STAGE, true, interaction.getOperation(), interaction.getQoSProperties(), (Object[]) null);
     }
     else
     {

--- a/src/main/java/esa/mo/mal/impl/MessageSend.java
+++ b/src/main/java/esa/mo/mal/impl/MessageSend.java
@@ -23,6 +23,7 @@ package esa.mo.mal.impl;
 import java.util.Date;
 import java.util.Hashtable;
 import java.util.List;
+import java.util.Map;
 import java.util.logging.Level;
 import org.ccsds.moims.mo.mal.*;
 import org.ccsds.moims.mo.mal.accesscontrol.MALAccessControl;
@@ -443,6 +444,7 @@ public class MessageSend
    * @param rspnInteractionStage Interaction stage to use on the response.
    * @param rspn Response message body.
    * @param isFinalStage True if this the final stage of the interaction.
+   * @param qosProperties The QoS properties.
    * @param operation The operation.
    * @return The sent MAL message.
    */
@@ -453,6 +455,7 @@ public class MessageSend
           final UOctet rspnInteractionStage,
           final boolean isFinalStage,
           final MALOperation operation,
+          final Map qosProperties,
           final Object... rspn)
   {
     MALMessage msg = null;
@@ -472,7 +475,7 @@ public class MessageSend
               false,
               operation,
               rspnInteractionStage,
-              new Hashtable(),
+              qosProperties,
               rspn);
 
       if (isFinalStage)
@@ -511,6 +514,7 @@ public class MessageSend
    * @param rspnInteractionStage Interaction stage to use on the response.
    * @param rspn Response encoded message body.
    * @param isFinalStage True if this the final stage of the interaction.
+   * @param qosProperties The QoS properties.
    * @param operation The operation.
    * @return The sent MAL message.
    */
@@ -521,6 +525,7 @@ public class MessageSend
           final UOctet rspnInteractionStage,
           final boolean isFinalStage,
           final MALOperation operation,
+          final Map qosProperties,
           final MALEncodedBody rspn)
   {
     MALMessage msg = null;
@@ -540,7 +545,7 @@ public class MessageSend
               false,
               operation,
               rspnInteractionStage,
-              new Hashtable(),
+              qosProperties,
               rspn);
 
       if (isFinalStage)

--- a/src/main/java/esa/mo/mal/impl/patterns/BaseInteractionImpl.java
+++ b/src/main/java/esa/mo/mal/impl/patterns/BaseInteractionImpl.java
@@ -126,6 +126,7 @@ public abstract class BaseInteractionImpl implements MALInteraction
             stage,
             isFinalStage,
             operation,
+            qosProperties,
             result);
   }
 
@@ -149,6 +150,7 @@ public abstract class BaseInteractionImpl implements MALInteraction
             stage,
             isFinalStage,
             operation,
+            qosProperties,
             body);
   }
 


### PR DESCRIPTION
QoS properties added to the active MALInteraction during execution of a handler method where not used when creating a response message. This has been corrected for normal messages, however not for error messages. This is because in the latter case it cannot be assured that the property map is correctly constructed if the handler exits with an exception.
